### PR TITLE
Add Pset0.v template and Pset0Check.v.

### DIFF
--- a/pset0/Pset0.v
+++ b/pset0/Pset0.v
@@ -1,0 +1,18 @@
+Require Import Frap.
+
+(* Replace "admit." with your solution. *)
+
+Theorem another_important_theorem : length [1; 2; 3] = 1 + length [4; 5].
+Proof.
+  admit.
+Qed.
+
+Theorem length_concat : forall A (xs ys : list A), length (xs ++ ys) = length xs + length ys.
+Proof.
+  admit.
+Qed.
+
+Theorem length_rev : forall A (xs : list A), length xs = length (rev xs).
+Proof.
+  admit.
+Qed.

--- a/pset0/Pset0Check.v
+++ b/pset0/Pset0Check.v
@@ -1,0 +1,3 @@
+Require Pset0Sig Pset0.
+
+Module M : Pset0Sig.S := Pset0.

--- a/pset0/_CoqProject
+++ b/pset0/_CoqProject
@@ -1,2 +1,4 @@
 -R ../frap Frap
 Pset0Sig.v
+Pset0.v
+Pset0Check.v


### PR DESCRIPTION
Peng, if you believe in minimizing the amount of manual setup that students have to do, I think these files should be added too.  It's a little late to matter for pset 0, but I'd like to start the trend.

The only potential drawback is that students who choose not to commit their version of Pset0.v locally will see it as a pending change rather than an untracked file and may be at greater risk of losing their work via careless use of git commands.  I think students should be encouraged to commit their solutions locally and this drawback is outweighed by the benefit.  But if you're concerned about it, another option would be to name the file Pset0_template.v and leave a manual step of `cp Pset0_template.v Pset0.v`, which is still an improvement on the status quo.
